### PR TITLE
Optionally reuse an ActiveDirectory instance

### DIFF
--- a/src/strategy.js
+++ b/src/strategy.js
@@ -58,8 +58,9 @@ function Strategy (options, verify) {
     this._usernameField = options.usernameField || DEFAULT_USERNAME_FIELD;
     this._passwordField = options.passwordField || DEFAULT_PASSWORD_FIELD;
   }
-
-  this._ad = new ActiveDirectory(options.ldap)
+  
+  if (typeof this._ad !== 'function') { this._ad = options.ldap }
+  else { this._ad = new ActiveDirectory(options.ldap) }
 }
 
 util.inherits(Strategy, passport.Strategy)


### PR DESCRIPTION
If you already have an ActiveDirectory instance, use it instead of creating a new one.

Exemple : 

```
[...]
var ad = new ActiveDirectory(options)
[...]
passport.use(new ActiveDirectoryStrategy({
  integrated: false,
  ldap: ad
[...]
```

If you provide an config object, a new instance will be created. Else, the existing one is used.
