### PR TITLE
change dependency activedirectory to activedirectory2

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'defau
 
 var util = _interopDefault(require('util'));
 var passport = _interopDefault(require('passport'));
-var ActiveDirectory = _interopDefault(require('activedirectory'));
+var ActiveDirectory = _interopDefault(require('activedirectory2'));
 
 /*
  * modified version of passport-windowsauth (https://github.com/auth0/passport-windowsauth)

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "author": "Branden Horiuchi <bhoriuchi@gmail.com>",
   "dependencies": {
-    "activedirectory": "^0.7.0",
+    "activedirectory2": "^2.1.0",
     "passport": "^0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Updated dependency to activedirectory2 because we've found problems related with groups with special characters.

Here's the problem: https://github.com/ldapjs/node-ldapjs/issues/621