### PR TITLE
chore: Bump passport version to 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Branden Horiuchi <bhoriuchi@gmail.com>",
   "dependencies": {
     "activedirectory2": "^2.1.0",
-    "passport": "^0.3.0"
+    "passport": "^0.6.0"
   },
   "devDependencies": {
     "rollup": "^0.34.10",


### PR DESCRIPTION
Bump passport version to 0.6.0 to mitigate [CVE-2022-25896](https://github.com/advisories/GHSA-v923-w3x8-wh69)

Resolves #13 