### PR TITLE
fix: fail, not error, on InvalidCredentialsError

### DIFF
--- a/src/strategy.js
+++ b/src/strategy.js
@@ -120,8 +120,13 @@ Strategy.prototype.authenticate = function (req, options = {}) {
 
   let auth = (userProfile) => {
     return this._ad.authenticate(userProfile._json.dn, password, (err, auth) => {
-      if (err) return this.error(err)
-      if (!auth) return this.fail(`Authentication failed for ${username}`)
+      const authFailureMessage = `Authentication failed for ${username}`
+      if (err) {
+        return err.prototype.name === 'InvalidCredentialsError'
+          ? this.fail(`${authFailureMessage}: [${err.message}]`)
+          : this.error(err)
+      }
+      if (!auth) return this.fail(authFailureMessage)
       return verify(userProfile)
     })
   }


### PR DESCRIPTION
activedirectory2 will return an InvalidCredentialsError if this strategy is used without integration (ie, config `integrated: false`), and if invalid credentials are given. Invoke `fail()` instead of `error()`, so that the caller knows that this is an auth failure rather than a system issue.

Fixes #5