### PR TITLE
fix: TypeError causes when auth failed

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ Strategy.prototype.authenticate = function (req) {
     return _this._ad.authenticate(userProfile._json.dn, password, function (err, auth) {
       var authFailureMessage = 'Authentication failed for ' + username;
       if (err) {
-        return err.prototype.name === 'InvalidCredentialsError' ? _this.fail(authFailureMessage + ': [' + err.message + ']') : _this.error(err);
+        return err.name === 'InvalidCredentialsError' ? _this.fail('' + authFailureMessage) : _this.error(err);
       }
       if (!auth) return _this.fail(authFailureMessage);
       return verify(userProfile);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "passport-activedirectory",
-  "version": "1.0.4",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "passport-activedirectory",
-      "version": "1.0.4",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "activedirectory2": "^2.1.0",
         "passport": "^0.6.0"
       },
       "devDependencies": {
-        "babel-preset-es2015-rollup": "^1.2.0",
+        "babel-preset-es2015-rollup": "^3.0.0",
         "rollup": "^0.34.10",
         "rollup-plugin-babel": "^2.6.1"
       }
@@ -555,14 +555,14 @@
       }
     },
     "node_modules/babel-preset-es2015-rollup": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2015-rollup/-/babel-preset-es2015-rollup-1.2.0.tgz",
-      "integrity": "sha512-x/FKWvh2BNoL1xC+5Q7gdNpVFp6Wk+f5VtECLXdN1kbFqHT9bBxLrlLhy9e678HSEOKgDc28UbHlCZhbNN+SNA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-es2015-rollup/-/babel-preset-es2015-rollup-3.0.0.tgz",
+      "integrity": "sha512-BNYsMpqTFKsEsLOK9lrgffn/PcA90Zgvga0EuehojUcGi2aL+URxZYyi7cKpUUyO3OOa2yILlY4aNZ5HfxlrCQ==",
       "dev": true,
       "dependencies": {
-        "babel-plugin-external-helpers": "^6.4.0",
+        "babel-plugin-external-helpers": "^6.18.0",
         "babel-preset-es2015": "^6.3.13",
-        "modify-babel-preset": "^2.1.1"
+        "require-relative": "^0.8.7"
       }
     },
     "node_modules/babel-register": {
@@ -938,15 +938,6 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/modify-babel-preset": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/modify-babel-preset/-/modify-babel-preset-2.1.1.tgz",
-      "integrity": "sha512-HumI/xZj3aLw0CaRJu/rmpV19rgPhA4BDJBYd8GkIpfWErCo3JdPIsLLIVh6HUUU4AAxMN1qKZJjNPtRWRGW+A==",
-      "dev": true,
-      "dependencies": {
-        "require-relative": "^0.8.7"
       }
     },
     "node_modules/ms": {
@@ -1797,14 +1788,14 @@
       }
     },
     "babel-preset-es2015-rollup": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2015-rollup/-/babel-preset-es2015-rollup-1.2.0.tgz",
-      "integrity": "sha512-x/FKWvh2BNoL1xC+5Q7gdNpVFp6Wk+f5VtECLXdN1kbFqHT9bBxLrlLhy9e678HSEOKgDc28UbHlCZhbNN+SNA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-es2015-rollup/-/babel-preset-es2015-rollup-3.0.0.tgz",
+      "integrity": "sha512-BNYsMpqTFKsEsLOK9lrgffn/PcA90Zgvga0EuehojUcGi2aL+URxZYyi7cKpUUyO3OOa2yILlY4aNZ5HfxlrCQ==",
       "dev": true,
       "requires": {
-        "babel-plugin-external-helpers": "^6.4.0",
+        "babel-plugin-external-helpers": "^6.18.0",
         "babel-preset-es2015": "^6.3.13",
-        "modify-babel-preset": "^2.1.1"
+        "require-relative": "^0.8.7"
       }
     },
     "babel-register": {
@@ -2112,15 +2103,6 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.6"
-      }
-    },
-    "modify-babel-preset": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/modify-babel-preset/-/modify-babel-preset-2.1.1.tgz",
-      "integrity": "sha512-HumI/xZj3aLw0CaRJu/rmpV19rgPhA4BDJBYd8GkIpfWErCo3JdPIsLLIVh6HUUU4AAxMN1qKZJjNPtRWRGW+A==",
-      "dev": true,
-      "requires": {
-        "require-relative": "^0.8.7"
       }
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "rollup": "^0.34.10",
     "rollup-plugin-babel": "^2.6.1",
-    "babel-preset-es2015-rollup": "^1.2.0"
+    "babel-preset-es2015-rollup": "^3.0.0"
   },
   "bugs": {
     "url": "https://github.com/bhoriuchi/passport-activedirectory/issues"

--- a/src/strategy.js
+++ b/src/strategy.js
@@ -122,8 +122,8 @@ Strategy.prototype.authenticate = function (req, options = {}) {
     return this._ad.authenticate(userProfile._json.dn, password, (err, auth) => {
       const authFailureMessage = `Authentication failed for ${username}`
       if (err) {
-        return err.prototype.name === 'InvalidCredentialsError'
-          ? this.fail(`${authFailureMessage}: [${err.message}]`)
+        return err.name === 'InvalidCredentialsError'
+          ? this.fail(`${authFailureMessage}`)
           : this.error(err)
       }
       if (!auth) return this.fail(authFailureMessage)


### PR DESCRIPTION
This PR is to fix the two points causing TypeError as follows:

1) The following error is due to that `err.prorotype` is undefined. 
```
/path/to/myproject/node_modules/passport-activedirectory/index.js:126
        return err.prototype.name === 'InvalidCredentialsError' ? _this.fail(authFailureMessage + ': [' + err.message + ']') : _this.error(err);
                             ^

TypeError: Cannot read properties of undefined (reading 'name')
  ...
```

`err.prototype.name` should be modified to `err.name`.
```
$ node
> const ldap = require('ldapjs');
> const err = new ldap.InvalidCredentialsError();
> console.log(err.prototype);
undefined
> console.log(err.name);
'InvalidCredentialsError'
>
```

2) The following error is caused after 1) is fixed. This error is disappeared by removing `': [' + err.message + ']'`.
```
node:_http_outgoing:624
    throw new ERR_INVALID_CHAR('header content', name);

TypeError [ERR_INVALID_CHAR]: Invalid character in header content ["WWW-Authenticate"]
  ...
```

In addition, I upgrade the version of `babel-preset-es2015-rollup` in `devDependencies` to solve build error.