### PR TITLE
refactor: add possibility to change 'users' to another field

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var ActiveDirectory = _interopDefault(require('activedirectory2'));
 
 var DEFAULT_USERNAME_FIELD = 'username';
 var DEFAULT_PASSWORD_FIELD = 'password';
-var DEFAULT_ATTRS = ['dn', 'displayName', 'givenName', 'sn', 'title', 'userPrincipalName', 'sAMAccountName', 'mail', 'description'];
+var DEFAULT_ATTRS = ['cn', 'dn', 'sn', 'displayName', 'givenName', 'title', 'userPrincipalName', 'sAMAccountName', 'mail', 'description', 'telephoneNumber', 'memberOf'];
 
 var DEFAULT_FILTER = function DEFAULT_FILTER(username) {
   return '(&(objectclass=user)(|(sAMAccountName=' + username + ')(UserPrincipalName=' + username + ')))';
@@ -132,6 +132,7 @@ Strategy.prototype.authenticate = function (req) {
 
   // look for the user if using ldap auth
   if (this._ad) {
+    var group = req.body.group || req.query.group || 'users';
     var ldap = this._options.ldap;
     var filter = typeof ldap.filter === 'function' ? ldap.filter(username) : DEFAULT_FILTER(username);
     var attributes = ldap.attributes || DEFAULT_ATTRS;
@@ -142,10 +143,10 @@ Strategy.prototype.authenticate = function (req) {
 
     return this._ad.find({ filter: filter, attributes: attributes }, function (err, results) {
       if (err) return _this.error(err);
-      if (!results || !results.users || !Array.isArray(results.users) || !results.users.length) {
+      if (!results || !results[group] || !Array.isArray(results[group]) || !results[group].length) {
         return _this.fail('The user "' + username + '" was not found');
       }
-      var userProfile = _this.mapProfile(results.users[0]);
+      var userProfile = _this.mapProfile(results[group][0]);
       return _this._integrated ? verify(userProfile) : auth(userProfile);
     });
   }

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ var ActiveDirectory = _interopDefault(require('activedirectory2'));
  *
  */
 
+var DEFAULT_GROUP_VALUE = 'users';
 var DEFAULT_USERNAME_FIELD = 'username';
 var DEFAULT_PASSWORD_FIELD = 'password';
 var DEFAULT_ATTRS = ['cn', 'dn', 'sn', 'displayName', 'givenName', 'title', 'userPrincipalName', 'sAMAccountName', 'mail', 'description', 'telephoneNumber', 'memberOf'];
@@ -47,6 +48,7 @@ function Strategy(options, verify) {
   this._passReqToCallback = options.passReqToCallback;
   this._integrated = options.integrated === false ? options.integrated : true;
   this._getUserNameFromHeader = options.getUserNameFromHeader || getUserNameFromHeader;
+  this._group = options.group;
 
   if (!this._integrated) {
     this._usernameField = options.usernameField || DEFAULT_USERNAME_FIELD;
@@ -132,7 +134,7 @@ Strategy.prototype.authenticate = function (req) {
 
   // look for the user if using ldap auth
   if (this._ad) {
-    var group = req.body.group || req.query.group || 'users';
+    var group = req.body.group || req.query.group || this._group || DEFAULT_GROUP_VALUE;
     var ldap = this._options.ldap;
     var filter = typeof ldap.filter === 'function' ? ldap.filter(username) : DEFAULT_FILTER(username);
     var attributes = ldap.attributes || DEFAULT_ATTRS;

--- a/src/strategy.js
+++ b/src/strategy.js
@@ -14,6 +14,7 @@ import ActiveDirectory from 'activedirectory2'
  *
  */
 
+const DEFAULT_GROUP_VALUE = 'users'
 const DEFAULT_USERNAME_FIELD = 'username'
 const DEFAULT_PASSWORD_FIELD = 'password'
 const DEFAULT_ATTRS = [
@@ -56,6 +57,7 @@ function Strategy (options, verify) {
   this._passReqToCallback = options.passReqToCallback
   this._integrated = options.integrated === false ? options.integrated : true
   this._getUserNameFromHeader = options.getUserNameFromHeader || getUserNameFromHeader
+  this._group = options.group;
 
   if (!this._integrated) {
     this._usernameField = options.usernameField || DEFAULT_USERNAME_FIELD;
@@ -136,7 +138,7 @@ Strategy.prototype.authenticate = function (req, options = {}) {
 
   // look for the user if using ldap auth
   if (this._ad) {
-    const group = req.body.group || req.query.group || 'users';
+    const group = req.body.group || req.query.group || this._group || DEFAULT_GROUP_VALUE;
     let ldap = this._options.ldap
     let filter = (typeof ldap.filter === 'function') ? ldap.filter(username) : DEFAULT_FILTER(username)
     let attributes = ldap.attributes || DEFAULT_ATTRS


### PR DESCRIPTION
I needed to use the library recently and had problems retrieving users, it turns out that the users I wanted were in 'others' and not in 'users'. Making this change above worked!